### PR TITLE
Add links for each Scribblette by name.

### DIFF
--- a/tso.html
+++ b/tso.html
@@ -39,10 +39,6 @@
 				</ul>
 			</div>
 			<div class="item">
-				<h3><a href="comic.html?comic=scribblettes">Scribblettes</a></h3>
-				<p>Even more casually rendered comics of a random nature.</p>
-			</div>
-			<div class="item">
 				<h3>Older Stuff</h3>
 				<ul>
 					<li><a href="comic.html?comic=ch">Caper Havers</a></li>
@@ -56,6 +52,1164 @@
 			<div class="item">
 				<h3><a href="comic.html?comic=wallpapers">Wallpapers</a></h3>
 				<p>Wallpapers.</p>
+			</div>
+			<div class="item">
+				<h3><a href="comic.html?comic=scribblettes">Scribblettes</a></h3>
+				<p>Even more casually rendered comics of a random nature.</p>
+                <table class="item" style="padding-top: 5px; margin-top: 5px;"><tbody>
+                    <tr>
+                        <td><b>06/18/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=288">.Com Boom Bubble</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/10/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=287">Bootstrap Beefstuds</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/21/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=286">The Greatest Adventure</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/11/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=285">Grown Man With A Ponytail</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/27/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=284">Horses Never Sleep</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/22/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=283">Grateful Joe</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/19/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=282">Horse Pope</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/09/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=281">Being Naked With Charlton Heston</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/03/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=280">False Hat</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/30/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=279">Imagining What Someone Looked Like as a Baby</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/27/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=278">Imagining What Someone Looked Like as a Baby</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/19/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=277">In Cahoots</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/18/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=276">The Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/18/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=275">The Tales Of Poodley P. McFustercluck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/14/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=274">Chimps Ahoy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/14/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=273">Porn Swogglers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/12/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=272">Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/12/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=271">Being Naked With Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/08/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=270">Corn Dogglers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/08/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=269">The Tales Of Poodley P. McFustercluck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/04/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=268">Great Detective</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/04/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=267">Being Naked With old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/30/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=266">The Tales Of Poodley P. McFustercluck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/30/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=265">Priest Fantasy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/27/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=264">The Best Coach</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/27/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=263">The Tales Of Poodley P. McFustercluck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/23/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=262">Horsey Pete</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/23/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=261">Retarded Clown</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/19/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=260">The Tales Of Poodley P. McFustercluck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/19/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=259">Horsey Pete</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/17/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=258">Computer Whiz</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/17/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=257">The Tales Of Poodley P. McFustercluck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/02/08</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=256">I'm Better Than Most People At Most Things</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/26/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=255">Pony Baloney</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=254">Toilet Mishap</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=253">Ape Mask</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/16/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=252">Street-Hunk Musclestuds</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=251">Bone Zone</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/26/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=250">Horsey Pete Being Naked with Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/21/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=249">Pancake Style</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/16/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=248">Spoon Injury</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/10/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=247">Horsey Pete</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/08/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=246">Horsey Pete</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/08/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=245">Sloppy Joe</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/08/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=244">Highway Robbery</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/05/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=243">Jurisdiction</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=242">Koalamity</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=241">Wedgie Connoisseur</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/02/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=240">Dinosaur High</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/01/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=239">Wine and Cheese Party</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/27/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=238">Voyeur Voyeur</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/26/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=237">Attorney at Flaw!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/24/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=236">Pappy Carruthers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/21/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=235">Fancy Lou</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/20/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=234">Not Pretending to Ignore a Fart</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/20/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=233">Secret Society</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/18/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=232">Soda Club</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/17/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=231">Papa John</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/14/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=230">Magic Trick</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/13/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=229">Space Aliens</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/12/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=228">Snork Porklers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/11/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=227">Rum Cake</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/10/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=226">Funky Boogaloo</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/05/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=225">Pie Contest</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=224">Funcle</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/03/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=223">Uncle Fun</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/31/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=222">Bards and Nobles</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/30/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=221">Bard Quest</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/29/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=220">Princess Enema</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/28/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=219">Dazzle Me!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/27/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=218">Rocket Hearse</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/24/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=217">Lazy Bones</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/23/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=216">Tripod</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=215">Feeding Weird Things to a Duck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/13/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=214">The Best Dance</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/10/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=213">Ripped!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/09/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=212">Weaponized Horse</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/06/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=211">Cut Budz</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/03/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=210">Ripped!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/02/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=209">Big Fun Papa!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>05/01/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=208">Cool Fonso</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/30/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=207">Lazy Susan</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/29/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=206">Leave it to Oregon!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/27/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=205">Ape Horse</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/27/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=204">Buying a Kettle</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/26/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=203">Family Follies</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/24/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=202">Eels! Eels! Eels!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/23/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=201">Warren the Rambunctious Pirate</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/19/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=200">The Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/18/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=199">Cob Farmer</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/18/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=198">Winning Contest</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/17/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=197">Ape Jape</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=196">Fish Wish</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/12/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=195">Silly Clowns</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/11/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=194">Hanky-Panky</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>04/10/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=193">Being Naked At Church</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/29/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=192">Feeding Weird Things to a Duck</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/28/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=191">Cuddling with Celebrities</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/27/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=190">Grateful Joe</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/26/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=189">Leave it to Oregon!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/25/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=188">Elsewho</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/22/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=187">Gamblin' Jeremy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/22/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=186">Best Infidel</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/20/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=185">Owning a Dog</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/19/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=184">Innocent Fun</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/18/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=183">What Has Science Done?</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=182">Horse Priest</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/14/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=181">Pretending to be Someone Else's Baby</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/13/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=180">Horse Judge</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/12/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=179">Island Pair O' Dice</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/11/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=178">Royal Treatment</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/09/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=177">Pork Snorklers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/07/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=176">Bad Platitude</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/07/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=175">Skinny Mister Lee</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/05/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=174">The Coolest Dude</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=173">Moustache Warriors</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>03/02/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=172">Cage Fighting Granny</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/28/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=171">Pope on a Rope</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/28/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=170">Time Travelling Horse</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/26/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=169">Cuddling with Celebrities</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/25/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=168">Grateful Joe</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/22/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=167">Fishing for Compliments</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/21/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=166">Gorilla Battle</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/20/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=165">Making Me Laugh at the Uni</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/19/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=164">Lumberjack Hijinks</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/18/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=163">Corpse Hunter</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=162">Surprise Visit From Alaska</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=161">Great Justice</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/14/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=160">No Cure for Stupid</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/13/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=159">Flapjack Pete</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/11/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=158">King Mutt</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/09/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=157">Beer Commercial</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/08/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=156">Being Naked With Old People and Grady</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/07/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=155">Pony Baloney</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/05/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=154">Big Black Mama</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=153">I've Got It!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>02/01/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=152">Space Star</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/31/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=151">Dumb Fetish</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/30/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=150">I'm Stumped!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/30/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=149">Puppet Show</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/28/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=148">Green Thumb</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/25/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=147">Lame Reward</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/24/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=146">Cornswogglers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/24/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=145">Banjo Blues</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/22/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=144">Big Game Hunter</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/21/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=143">Funny Prank</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/19/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=142">Cone Fan</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/17/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=141">Ankle-Deep In Horse Shit</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/16/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=140">Unviable Fetal Anomally</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/15/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=139">Jack-Be-Nimble</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/14/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=138">Great Dance</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/11/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=137">Juggle Queen</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/11/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=136">Jungle Queen</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/09/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=135">Turd-Rex</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/08/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=134">Legendary Cowboy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/07/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=133">Trolley Follies</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/05/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=132">Fun Surprise</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/04/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=131">Tony Shalhoub</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/02/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=130">Unethical Comic</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/02/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=129">Stupid Friends</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>01/01/07</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=128">The Best Butler</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/20/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=127">Unusual Wedding Ceremony</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/19/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=126">Grateful Joe</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/17/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=125">Detective Blowjob</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=124">Criminal Detective</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/13/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=123">Carnival Caper</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/12/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=122">Karate-Fu</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/11/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=121">Unpleasant Jim</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/11/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=120">Cheese Times</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/07/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=119">Lame Daydream</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/06/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=118">Not Pretending to Ignore a Fart</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/05/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=117">Funny Faces</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/04/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=116">Pork Oinklers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>12/03/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=115">Steve Fucker</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/23/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=114">Unwarranted Erection</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/22/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=113">Snowman Impersonator</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/21/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=112">Robophilia</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/21/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=111">Awake at the Wheel</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/19/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=110">Blimp Ace</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/17/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=109">Steve Eater</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/15/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=108">A Boy and His Iron</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/15/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=107">Ape Fighter</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=106">Idiotic Fantasy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/12/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=105">Rave Reviews!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/09/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=104">Poop Palace</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/09/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=103">Voyage To The Center Of The Sun</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/07/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=102">Bastard Saver</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/07/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=101">Being Billy Whitaker</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/06/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=100">Being Naked With Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/02/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=099">Free Corn</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>11/02/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=098">Underground Funk Railroad</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/31/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=097">Pretending To Be Someone's Baby</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/31/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=096">Dumpy Dykes</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/27/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=095">Robocycle</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/25/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=094">Clean Sweep!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/23/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=093">Stupid-Seeking Missile</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/23/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=092">Coffin Swap</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/20/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=091">Tumor Rick</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/19/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=090">Spice Fan</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/17/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=089">Ugly Gonzalez</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/16/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=088">Sports Hero</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/15/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=087">The Smartest Student</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/12/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=086">Being Naked With Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/11/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=085">Surly Earl</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/10/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=084">Math-Master</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/09/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=083">The Modern Homosexual</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/08/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=082">Brain Food</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/05/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=081">The Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/04/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=080">Fun Uncle</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/03/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=079">Excellent Friend</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/02/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=078">Loveable Family Member</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>10/01/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=077">Class Act</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/28/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=076">Naturally Great Guy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/27/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=075">Ultra Fine Human</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/26/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=074">Mayhem Madness</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/25/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=073">NBA Dreams!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/24/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=072">Being Naked With Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/21/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=071">Cool Helmet</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/20/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=070">What if???</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/19/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=069">Count Bloodula</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/18/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=068">Funky Fun!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/17/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=067">The Boy Who Lied</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=066">The Best Winner</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=065">Great Ambition</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/12/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=064">Cal-I'm-Sorry Calamari</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/11/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=063">Calamari Calamity</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/10/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=062">Clam Calamity</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>09/07/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=061">Claus for Alarm</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/29/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=060">Prostitution</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/27/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=059">Cubix</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/25/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=058">The Ugliest Girl</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/23/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=057">Birthday Hooray</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/22/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=056">Jungle Fever</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/21/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=055">Magic Train Land</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/20/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=054">Polish Roulette</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/18/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=053">Hey! Whatchoo Lookin' At?</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/17/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=052">Famous Ape</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/16/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=051">Rocket Boat!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=050">The Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/13/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=049">Being Naked With Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/10/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=048">Porn Problem</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/10/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=047">Dildo Dilemma</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/08/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=046">Dill Dilemma</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/08/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=045">Corn Conundrum</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/07/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=044">Macho Bernard</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/04/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=043">Macho Steve</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/03/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=042">Horndogglers</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/02/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=041">Cool Squad</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>08/01/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=040">Rollin' Wit Lil' Cal</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/30/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=039">Amazing Albert</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/27/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=038">It's a Girl!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/26/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=037">Liver and Bunyons</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/25/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=036">The Winston-Lomville Corn Tribune Herald</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/25/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=035">Wig Fan</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/23/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=034">World's Biggest Asshole</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/20/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=033">Stupid Dream</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/19/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=032">Air-Tight Alibi</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/18/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=031">Amusement Park for Dads</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/17/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=030">Dumb Wish</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/16/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=029">Fashion Blunder</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=028">Big Celebrity</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/13/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=027">Chess Masters</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/11/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=026">Scary Serpents</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/10/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=025">The Hunters</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/10/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=024">Wife Swap</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/06/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=023">Queen for a Day</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/05/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=022">What Would You Do for a Thousand Bucks?</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/04/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=021">Unwelcome Guests</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/03/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=020">Being Naked With Old People</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>07/02/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=019">Best Moustache</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/29/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=018">Bert &amp; Ernie</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/29/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=017">Hang Gliding Cowboy</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/27/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=016">Weird Sandwich</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/26/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=015">Horse Surgeon</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/25/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=014">The Colossus</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/22/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=013">Slamburgers!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/21/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=012">For Better Or For Wurst</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/20/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=011">In Charge of Dogs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/19/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=010">Pillow Talk</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/18/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=009">The Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/16/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=008">Phallic Spoon</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/14/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=007">Weird Hobo</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/13/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=006">Great Comedian</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/12/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=005">Farting Pirate</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/11/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=004">The Roarosaurs</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/09/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=003">Pink Slip!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/07/06</b></td>
+                        <td><a href="comic.html?comic=scribblettes&page=002">Outta Sight!</a></td>
+                    </tr>
+                    <tr>
+                        <td><b>06/06/06</b></td>
+                            <td><a href="comic.html?comic=scribblettes&page=001">Being Naked With Old People</a></td>
+                    </tr>
+                </tbody></table>
 			</div>
 		</div>
 		<div class="footer">

--- a/tso.html
+++ b/tso.html
@@ -56,1160 +56,1160 @@
 			<div class="item">
 				<h3><a href="comic.html?comic=scribblettes">Scribblettes</a></h3>
 				<p>Even more casually rendered comics of a random nature.</p>
-                <table class="item" style="padding-top: 5px; margin-top: 5px;"><tbody>
-                    <tr>
-                        <td><b>06/18/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=288">.Com Boom Bubble</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/10/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=287">Bootstrap Beefstuds</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/21/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=286">The Greatest Adventure</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/11/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=285">Grown Man With A Ponytail</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/27/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=284">Horses Never Sleep</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/22/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=283">Grateful Joe</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/19/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=282">Horse Pope</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/09/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=281">Being Naked With Charlton Heston</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/03/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=280">False Hat</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/30/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=279">Imagining What Someone Looked Like as a Baby</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/27/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=278">Imagining What Someone Looked Like as a Baby</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/19/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=277">In Cahoots</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/18/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=276">The Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/18/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=275">The Tales Of Poodley P. McFustercluck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/14/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=274">Chimps Ahoy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/14/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=273">Porn Swogglers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/12/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=272">Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/12/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=271">Being Naked With Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/08/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=270">Corn Dogglers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/08/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=269">The Tales Of Poodley P. McFustercluck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/04/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=268">Great Detective</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/04/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=267">Being Naked With old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/30/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=266">The Tales Of Poodley P. McFustercluck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/30/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=265">Priest Fantasy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/27/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=264">The Best Coach</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/27/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=263">The Tales Of Poodley P. McFustercluck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/23/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=262">Horsey Pete</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/23/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=261">Retarded Clown</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/19/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=260">The Tales Of Poodley P. McFustercluck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/19/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=259">Horsey Pete</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/17/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=258">Computer Whiz</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/17/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=257">The Tales Of Poodley P. McFustercluck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/02/08</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=256">I'm Better Than Most People At Most Things</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/26/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=255">Pony Baloney</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=254">Toilet Mishap</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=253">Ape Mask</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/16/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=252">Street-Hunk Musclestuds</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=251">Bone Zone</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/26/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=250">Horsey Pete Being Naked with Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/21/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=249">Pancake Style</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/16/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=248">Spoon Injury</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/10/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=247">Horsey Pete</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/08/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=246">Horsey Pete</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/08/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=245">Sloppy Joe</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/08/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=244">Highway Robbery</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/05/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=243">Jurisdiction</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=242">Koalamity</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=241">Wedgie Connoisseur</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/02/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=240">Dinosaur High</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/01/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=239">Wine and Cheese Party</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/27/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=238">Voyeur Voyeur</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/26/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=237">Attorney at Flaw!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/24/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=236">Pappy Carruthers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/21/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=235">Fancy Lou</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/20/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=234">Not Pretending to Ignore a Fart</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/20/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=233">Secret Society</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/18/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=232">Soda Club</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/17/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=231">Papa John</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/14/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=230">Magic Trick</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/13/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=229">Space Aliens</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/12/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=228">Snork Porklers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/11/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=227">Rum Cake</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/10/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=226">Funky Boogaloo</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/05/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=225">Pie Contest</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=224">Funcle</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/03/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=223">Uncle Fun</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/31/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=222">Bards and Nobles</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/30/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=221">Bard Quest</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/29/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=220">Princess Enema</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/28/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=219">Dazzle Me!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/27/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=218">Rocket Hearse</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/24/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=217">Lazy Bones</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/23/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=216">Tripod</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=215">Feeding Weird Things to a Duck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/13/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=214">The Best Dance</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/10/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=213">Ripped!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/09/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=212">Weaponized Horse</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/06/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=211">Cut Budz</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/03/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=210">Ripped!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/02/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=209">Big Fun Papa!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>05/01/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=208">Cool Fonso</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/30/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=207">Lazy Susan</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/29/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=206">Leave it to Oregon!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/27/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=205">Ape Horse</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/27/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=204">Buying a Kettle</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/26/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=203">Family Follies</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/24/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=202">Eels! Eels! Eels!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/23/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=201">Warren the Rambunctious Pirate</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/19/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=200">The Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/18/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=199">Cob Farmer</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/18/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=198">Winning Contest</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/17/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=197">Ape Jape</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=196">Fish Wish</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/12/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=195">Silly Clowns</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/11/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=194">Hanky-Panky</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>04/10/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=193">Being Naked At Church</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/29/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=192">Feeding Weird Things to a Duck</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/28/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=191">Cuddling with Celebrities</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/27/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=190">Grateful Joe</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/26/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=189">Leave it to Oregon!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/25/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=188">Elsewho</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/22/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=187">Gamblin' Jeremy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/22/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=186">Best Infidel</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/20/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=185">Owning a Dog</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/19/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=184">Innocent Fun</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/18/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=183">What Has Science Done?</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=182">Horse Priest</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/14/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=181">Pretending to be Someone Else's Baby</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/13/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=180">Horse Judge</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/12/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=179">Island Pair O' Dice</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/11/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=178">Royal Treatment</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/09/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=177">Pork Snorklers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/07/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=176">Bad Platitude</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/07/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=175">Skinny Mister Lee</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/05/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=174">The Coolest Dude</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=173">Moustache Warriors</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>03/02/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=172">Cage Fighting Granny</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/28/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=171">Pope on a Rope</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/28/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=170">Time Travelling Horse</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/26/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=169">Cuddling with Celebrities</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/25/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=168">Grateful Joe</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/22/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=167">Fishing for Compliments</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/21/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=166">Gorilla Battle</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/20/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=165">Making Me Laugh at the Uni</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/19/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=164">Lumberjack Hijinks</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/18/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=163">Corpse Hunter</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=162">Surprise Visit From Alaska</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=161">Great Justice</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/14/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=160">No Cure for Stupid</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/13/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=159">Flapjack Pete</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/11/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=158">King Mutt</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/09/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=157">Beer Commercial</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/08/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=156">Being Naked With Old People and Grady</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/07/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=155">Pony Baloney</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/05/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=154">Big Black Mama</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=153">I've Got It!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>02/01/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=152">Space Star</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/31/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=151">Dumb Fetish</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/30/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=150">I'm Stumped!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/30/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=149">Puppet Show</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/28/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=148">Green Thumb</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/25/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=147">Lame Reward</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/24/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=146">Cornswogglers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/24/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=145">Banjo Blues</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/22/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=144">Big Game Hunter</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/21/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=143">Funny Prank</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/19/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=142">Cone Fan</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/17/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=141">Ankle-Deep In Horse Shit</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/16/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=140">Unviable Fetal Anomally</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/15/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=139">Jack-Be-Nimble</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/14/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=138">Great Dance</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/11/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=137">Juggle Queen</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/11/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=136">Jungle Queen</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/09/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=135">Turd-Rex</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/08/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=134">Legendary Cowboy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/07/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=133">Trolley Follies</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/05/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=132">Fun Surprise</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/04/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=131">Tony Shalhoub</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/02/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=130">Unethical Comic</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/02/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=129">Stupid Friends</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>01/01/07</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=128">The Best Butler</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/20/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=127">Unusual Wedding Ceremony</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/19/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=126">Grateful Joe</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/17/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=125">Detective Blowjob</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=124">Criminal Detective</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/13/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=123">Carnival Caper</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/12/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=122">Karate-Fu</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/11/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=121">Unpleasant Jim</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/11/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=120">Cheese Times</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/07/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=119">Lame Daydream</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/06/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=118">Not Pretending to Ignore a Fart</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/05/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=117">Funny Faces</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/04/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=116">Pork Oinklers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>12/03/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=115">Steve Fucker</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/23/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=114">Unwarranted Erection</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/22/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=113">Snowman Impersonator</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/21/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=112">Robophilia</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/21/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=111">Awake at the Wheel</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/19/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=110">Blimp Ace</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/17/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=109">Steve Eater</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/15/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=108">A Boy and His Iron</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/15/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=107">Ape Fighter</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=106">Idiotic Fantasy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/12/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=105">Rave Reviews!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/09/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=104">Poop Palace</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/09/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=103">Voyage To The Center Of The Sun</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/07/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=102">Bastard Saver</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/07/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=101">Being Billy Whitaker</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/06/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=100">Being Naked With Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/02/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=099">Free Corn</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>11/02/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=098">Underground Funk Railroad</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/31/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=097">Pretending To Be Someone's Baby</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/31/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=096">Dumpy Dykes</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/27/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=095">Robocycle</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/25/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=094">Clean Sweep!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/23/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=093">Stupid-Seeking Missile</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/23/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=092">Coffin Swap</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/20/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=091">Tumor Rick</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/19/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=090">Spice Fan</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/17/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=089">Ugly Gonzalez</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/16/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=088">Sports Hero</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/15/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=087">The Smartest Student</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/12/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=086">Being Naked With Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/11/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=085">Surly Earl</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/10/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=084">Math-Master</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/09/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=083">The Modern Homosexual</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/08/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=082">Brain Food</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/05/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=081">The Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/04/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=080">Fun Uncle</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/03/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=079">Excellent Friend</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/02/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=078">Loveable Family Member</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>10/01/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=077">Class Act</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/28/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=076">Naturally Great Guy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/27/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=075">Ultra Fine Human</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/26/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=074">Mayhem Madness</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/25/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=073">NBA Dreams!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/24/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=072">Being Naked With Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/21/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=071">Cool Helmet</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/20/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=070">What if???</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/19/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=069">Count Bloodula</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/18/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=068">Funky Fun!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/17/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=067">The Boy Who Lied</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=066">The Best Winner</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=065">Great Ambition</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/12/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=064">Cal-I'm-Sorry Calamari</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/11/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=063">Calamari Calamity</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/10/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=062">Clam Calamity</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>09/07/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=061">Claus for Alarm</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/29/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=060">Prostitution</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/27/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=059">Cubix</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/25/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=058">The Ugliest Girl</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/23/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=057">Birthday Hooray</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/22/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=056">Jungle Fever</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/21/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=055">Magic Train Land</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/20/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=054">Polish Roulette</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/18/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=053">Hey! Whatchoo Lookin' At?</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/17/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=052">Famous Ape</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/16/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=051">Rocket Boat!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=050">The Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/13/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=049">Being Naked With Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/10/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=048">Porn Problem</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/10/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=047">Dildo Dilemma</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/08/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=046">Dill Dilemma</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/08/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=045">Corn Conundrum</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/07/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=044">Macho Bernard</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/04/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=043">Macho Steve</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/03/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=042">Horndogglers</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/02/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=041">Cool Squad</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>08/01/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=040">Rollin' Wit Lil' Cal</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/30/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=039">Amazing Albert</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/27/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=038">It's a Girl!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/26/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=037">Liver and Bunyons</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/25/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=036">The Winston-Lomville Corn Tribune Herald</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/25/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=035">Wig Fan</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/23/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=034">World's Biggest Asshole</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/20/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=033">Stupid Dream</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/19/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=032">Air-Tight Alibi</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/18/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=031">Amusement Park for Dads</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/17/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=030">Dumb Wish</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/16/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=029">Fashion Blunder</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=028">Big Celebrity</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/13/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=027">Chess Masters</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/11/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=026">Scary Serpents</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/10/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=025">The Hunters</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/10/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=024">Wife Swap</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/06/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=023">Queen for a Day</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/05/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=022">What Would You Do for a Thousand Bucks?</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/04/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=021">Unwelcome Guests</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/03/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=020">Being Naked With Old People</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>07/02/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=019">Best Moustache</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/29/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=018">Bert &amp; Ernie</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/29/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=017">Hang Gliding Cowboy</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/27/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=016">Weird Sandwich</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/26/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=015">Horse Surgeon</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/25/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=014">The Colossus</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/22/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=013">Slamburgers!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/21/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=012">For Better Or For Wurst</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/20/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=011">In Charge of Dogs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/19/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=010">Pillow Talk</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/18/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=009">The Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/16/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=008">Phallic Spoon</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/14/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=007">Weird Hobo</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/13/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=006">Great Comedian</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/12/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=005">Farting Pirate</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/11/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=004">The Roarosaurs</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/09/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=003">Pink Slip!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/07/06</b></td>
-                        <td><a href="comic.html?comic=scribblettes&page=002">Outta Sight!</a></td>
-                    </tr>
-                    <tr>
-                        <td><b>06/06/06</b></td>
-                            <td><a href="comic.html?comic=scribblettes&page=001">Being Naked With Old People</a></td>
-                    </tr>
-                </tbody></table>
+				<table class="item" style="padding-top: 5px; margin-top: 5px;"><tbody>
+					<tr>
+						<td><b>06/18/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=288">.Com Boom Bubble</a></td>
+					</tr>
+					<tr>
+						<td><b>06/10/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=287">Bootstrap Beefstuds</a></td>
+					</tr>
+					<tr>
+						<td><b>05/21/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=286">The Greatest Adventure</a></td>
+					</tr>
+					<tr>
+						<td><b>05/11/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=285">Grown Man With A Ponytail</a></td>
+					</tr>
+					<tr>
+						<td><b>04/27/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=284">Horses Never Sleep</a></td>
+					</tr>
+					<tr>
+						<td><b>04/22/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=283">Grateful Joe</a></td>
+					</tr>
+					<tr>
+						<td><b>04/19/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=282">Horse Pope</a></td>
+					</tr>
+					<tr>
+						<td><b>04/09/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=281">Being Naked With Charlton Heston</a></td>
+					</tr>
+					<tr>
+						<td><b>04/03/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=280">False Hat</a></td>
+					</tr>
+					<tr>
+						<td><b>03/30/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=279">Imagining What Someone Looked Like as a Baby</a></td>
+					</tr>
+					<tr>
+						<td><b>03/27/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=278">Imagining What Someone Looked Like as a Baby</a></td>
+					</tr>
+					<tr>
+						<td><b>03/19/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=277">In Cahoots</a></td>
+					</tr>
+					<tr>
+						<td><b>02/18/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=276">The Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>02/18/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=275">The Tales Of Poodley P. McFustercluck</a></td>
+					</tr>
+					<tr>
+						<td><b>02/14/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=274">Chimps Ahoy</a></td>
+					</tr>
+					<tr>
+						<td><b>02/14/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=273">Porn Swogglers</a></td>
+					</tr>
+					<tr>
+						<td><b>02/12/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=272">Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>02/12/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=271">Being Naked With Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>02/08/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=270">Corn Dogglers</a></td>
+					</tr>
+					<tr>
+						<td><b>02/08/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=269">The Tales Of Poodley P. McFustercluck</a></td>
+					</tr>
+					<tr>
+						<td><b>02/04/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=268">Great Detective</a></td>
+					</tr>
+					<tr>
+						<td><b>02/04/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=267">Being Naked With old People</a></td>
+					</tr>
+					<tr>
+						<td><b>01/30/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=266">The Tales Of Poodley P. McFustercluck</a></td>
+					</tr>
+					<tr>
+						<td><b>01/30/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=265">Priest Fantasy</a></td>
+					</tr>
+					<tr>
+						<td><b>01/27/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=264">The Best Coach</a></td>
+					</tr>
+					<tr>
+						<td><b>01/27/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=263">The Tales Of Poodley P. McFustercluck</a></td>
+					</tr>
+					<tr>
+						<td><b>01/23/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=262">Horsey Pete</a></td>
+					</tr>
+					<tr>
+						<td><b>01/23/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=261">Retarded Clown</a></td>
+					</tr>
+					<tr>
+						<td><b>01/19/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=260">The Tales Of Poodley P. McFustercluck</a></td>
+					</tr>
+					<tr>
+						<td><b>01/19/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=259">Horsey Pete</a></td>
+					</tr>
+					<tr>
+						<td><b>01/17/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=258">Computer Whiz</a></td>
+					</tr>
+					<tr>
+						<td><b>01/17/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=257">The Tales Of Poodley P. McFustercluck</a></td>
+					</tr>
+					<tr>
+						<td><b>01/02/08</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=256">I'm Better Than Most People At Most Things</a></td>
+					</tr>
+					<tr>
+						<td><b>10/26/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=255">Pony Baloney</a></td>
+					</tr>
+					<tr>
+						<td><b>10/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=254">Toilet Mishap</a></td>
+					</tr>
+					<tr>
+						<td><b>10/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=253">Ape Mask</a></td>
+					</tr>
+					<tr>
+						<td><b>09/16/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=252">Street-Hunk Musclestuds</a></td>
+					</tr>
+					<tr>
+						<td><b>09/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=251">Bone Zone</a></td>
+					</tr>
+					<tr>
+						<td><b>08/26/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=250">Horsey Pete Being Naked with Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>08/21/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=249">Pancake Style</a></td>
+					</tr>
+					<tr>
+						<td><b>08/16/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=248">Spoon Injury</a></td>
+					</tr>
+					<tr>
+						<td><b>08/10/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=247">Horsey Pete</a></td>
+					</tr>
+					<tr>
+						<td><b>07/08/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=246">Horsey Pete</a></td>
+					</tr>
+					<tr>
+						<td><b>07/08/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=245">Sloppy Joe</a></td>
+					</tr>
+					<tr>
+						<td><b>07/08/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=244">Highway Robbery</a></td>
+					</tr>
+					<tr>
+						<td><b>07/05/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=243">Jurisdiction</a></td>
+					</tr>
+					<tr>
+						<td><b>07/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=242">Koalamity</a></td>
+					</tr>
+					<tr>
+						<td><b>07/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=241">Wedgie Connoisseur</a></td>
+					</tr>
+					<tr>
+						<td><b>07/02/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=240">Dinosaur High</a></td>
+					</tr>
+					<tr>
+						<td><b>07/01/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=239">Wine and Cheese Party</a></td>
+					</tr>
+					<tr>
+						<td><b>06/27/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=238">Voyeur Voyeur</a></td>
+					</tr>
+					<tr>
+						<td><b>06/26/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=237">Attorney at Flaw!</a></td>
+					</tr>
+					<tr>
+						<td><b>06/24/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=236">Pappy Carruthers</a></td>
+					</tr>
+					<tr>
+						<td><b>06/21/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=235">Fancy Lou</a></td>
+					</tr>
+					<tr>
+						<td><b>06/20/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=234">Not Pretending to Ignore a Fart</a></td>
+					</tr>
+					<tr>
+						<td><b>06/20/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=233">Secret Society</a></td>
+					</tr>
+					<tr>
+						<td><b>06/18/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=232">Soda Club</a></td>
+					</tr>
+					<tr>
+						<td><b>06/17/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=231">Papa John</a></td>
+					</tr>
+					<tr>
+						<td><b>06/14/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=230">Magic Trick</a></td>
+					</tr>
+					<tr>
+						<td><b>06/13/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=229">Space Aliens</a></td>
+					</tr>
+					<tr>
+						<td><b>06/12/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=228">Snork Porklers</a></td>
+					</tr>
+					<tr>
+						<td><b>06/11/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=227">Rum Cake</a></td>
+					</tr>
+					<tr>
+						<td><b>06/10/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=226">Funky Boogaloo</a></td>
+					</tr>
+					<tr>
+						<td><b>06/05/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=225">Pie Contest</a></td>
+					</tr>
+					<tr>
+						<td><b>06/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=224">Funcle</a></td>
+					</tr>
+					<tr>
+						<td><b>06/03/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=223">Uncle Fun</a></td>
+					</tr>
+					<tr>
+						<td><b>05/31/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=222">Bards and Nobles</a></td>
+					</tr>
+					<tr>
+						<td><b>05/30/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=221">Bard Quest</a></td>
+					</tr>
+					<tr>
+						<td><b>05/29/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=220">Princess Enema</a></td>
+					</tr>
+					<tr>
+						<td><b>05/28/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=219">Dazzle Me!</a></td>
+					</tr>
+					<tr>
+						<td><b>05/27/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=218">Rocket Hearse</a></td>
+					</tr>
+					<tr>
+						<td><b>05/24/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=217">Lazy Bones</a></td>
+					</tr>
+					<tr>
+						<td><b>05/23/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=216">Tripod</a></td>
+					</tr>
+					<tr>
+						<td><b>05/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=215">Feeding Weird Things to a Duck</a></td>
+					</tr>
+					<tr>
+						<td><b>05/13/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=214">The Best Dance</a></td>
+					</tr>
+					<tr>
+						<td><b>05/10/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=213">Ripped!</a></td>
+					</tr>
+					<tr>
+						<td><b>05/09/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=212">Weaponized Horse</a></td>
+					</tr>
+					<tr>
+						<td><b>05/06/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=211">Cut Budz</a></td>
+					</tr>
+					<tr>
+						<td><b>05/03/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=210">Ripped!</a></td>
+					</tr>
+					<tr>
+						<td><b>05/02/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=209">Big Fun Papa!</a></td>
+					</tr>
+					<tr>
+						<td><b>05/01/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=208">Cool Fonso</a></td>
+					</tr>
+					<tr>
+						<td><b>04/30/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=207">Lazy Susan</a></td>
+					</tr>
+					<tr>
+						<td><b>04/29/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=206">Leave it to Oregon!</a></td>
+					</tr>
+					<tr>
+						<td><b>04/27/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=205">Ape Horse</a></td>
+					</tr>
+					<tr>
+						<td><b>04/27/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=204">Buying a Kettle</a></td>
+					</tr>
+					<tr>
+						<td><b>04/26/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=203">Family Follies</a></td>
+					</tr>
+					<tr>
+						<td><b>04/24/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=202">Eels! Eels! Eels!</a></td>
+					</tr>
+					<tr>
+						<td><b>04/23/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=201">Warren the Rambunctious Pirate</a></td>
+					</tr>
+					<tr>
+						<td><b>04/19/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=200">The Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>04/18/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=199">Cob Farmer</a></td>
+					</tr>
+					<tr>
+						<td><b>04/18/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=198">Winning Contest</a></td>
+					</tr>
+					<tr>
+						<td><b>04/17/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=197">Ape Jape</a></td>
+					</tr>
+					<tr>
+						<td><b>04/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=196">Fish Wish</a></td>
+					</tr>
+					<tr>
+						<td><b>04/12/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=195">Silly Clowns</a></td>
+					</tr>
+					<tr>
+						<td><b>04/11/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=194">Hanky-Panky</a></td>
+					</tr>
+					<tr>
+						<td><b>04/10/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=193">Being Naked At Church</a></td>
+					</tr>
+					<tr>
+						<td><b>03/29/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=192">Feeding Weird Things to a Duck</a></td>
+					</tr>
+					<tr>
+						<td><b>03/28/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=191">Cuddling with Celebrities</a></td>
+					</tr>
+					<tr>
+						<td><b>03/27/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=190">Grateful Joe</a></td>
+					</tr>
+					<tr>
+						<td><b>03/26/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=189">Leave it to Oregon!</a></td>
+					</tr>
+					<tr>
+						<td><b>03/25/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=188">Elsewho</a></td>
+					</tr>
+					<tr>
+						<td><b>03/22/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=187">Gamblin' Jeremy</a></td>
+					</tr>
+					<tr>
+						<td><b>03/22/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=186">Best Infidel</a></td>
+					</tr>
+					<tr>
+						<td><b>03/20/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=185">Owning a Dog</a></td>
+					</tr>
+					<tr>
+						<td><b>03/19/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=184">Innocent Fun</a></td>
+					</tr>
+					<tr>
+						<td><b>03/18/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=183">What Has Science Done?</a></td>
+					</tr>
+					<tr>
+						<td><b>03/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=182">Horse Priest</a></td>
+					</tr>
+					<tr>
+						<td><b>03/14/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=181">Pretending to be Someone Else's Baby</a></td>
+					</tr>
+					<tr>
+						<td><b>03/13/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=180">Horse Judge</a></td>
+					</tr>
+					<tr>
+						<td><b>03/12/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=179">Island Pair O' Dice</a></td>
+					</tr>
+					<tr>
+						<td><b>03/11/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=178">Royal Treatment</a></td>
+					</tr>
+					<tr>
+						<td><b>03/09/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=177">Pork Snorklers</a></td>
+					</tr>
+					<tr>
+						<td><b>03/07/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=176">Bad Platitude</a></td>
+					</tr>
+					<tr>
+						<td><b>03/07/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=175">Skinny Mister Lee</a></td>
+					</tr>
+					<tr>
+						<td><b>03/05/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=174">The Coolest Dude</a></td>
+					</tr>
+					<tr>
+						<td><b>03/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=173">Moustache Warriors</a></td>
+					</tr>
+					<tr>
+						<td><b>03/02/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=172">Cage Fighting Granny</a></td>
+					</tr>
+					<tr>
+						<td><b>02/28/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=171">Pope on a Rope</a></td>
+					</tr>
+					<tr>
+						<td><b>02/28/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=170">Time Travelling Horse</a></td>
+					</tr>
+					<tr>
+						<td><b>02/26/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=169">Cuddling with Celebrities</a></td>
+					</tr>
+					<tr>
+						<td><b>02/25/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=168">Grateful Joe</a></td>
+					</tr>
+					<tr>
+						<td><b>02/22/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=167">Fishing for Compliments</a></td>
+					</tr>
+					<tr>
+						<td><b>02/21/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=166">Gorilla Battle</a></td>
+					</tr>
+					<tr>
+						<td><b>02/20/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=165">Making Me Laugh at the Uni</a></td>
+					</tr>
+					<tr>
+						<td><b>02/19/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=164">Lumberjack Hijinks</a></td>
+					</tr>
+					<tr>
+						<td><b>02/18/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=163">Corpse Hunter</a></td>
+					</tr>
+					<tr>
+						<td><b>02/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=162">Surprise Visit From Alaska</a></td>
+					</tr>
+					<tr>
+						<td><b>02/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=161">Great Justice</a></td>
+					</tr>
+					<tr>
+						<td><b>02/14/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=160">No Cure for Stupid</a></td>
+					</tr>
+					<tr>
+						<td><b>02/13/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=159">Flapjack Pete</a></td>
+					</tr>
+					<tr>
+						<td><b>02/11/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=158">King Mutt</a></td>
+					</tr>
+					<tr>
+						<td><b>02/09/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=157">Beer Commercial</a></td>
+					</tr>
+					<tr>
+						<td><b>02/08/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=156">Being Naked With Old People and Grady</a></td>
+					</tr>
+					<tr>
+						<td><b>02/07/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=155">Pony Baloney</a></td>
+					</tr>
+					<tr>
+						<td><b>02/05/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=154">Big Black Mama</a></td>
+					</tr>
+					<tr>
+						<td><b>02/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=153">I've Got It!</a></td>
+					</tr>
+					<tr>
+						<td><b>02/01/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=152">Space Star</a></td>
+					</tr>
+					<tr>
+						<td><b>01/31/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=151">Dumb Fetish</a></td>
+					</tr>
+					<tr>
+						<td><b>01/30/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=150">I'm Stumped!</a></td>
+					</tr>
+					<tr>
+						<td><b>01/30/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=149">Puppet Show</a></td>
+					</tr>
+					<tr>
+						<td><b>01/28/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=148">Green Thumb</a></td>
+					</tr>
+					<tr>
+						<td><b>01/25/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=147">Lame Reward</a></td>
+					</tr>
+					<tr>
+						<td><b>01/24/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=146">Cornswogglers</a></td>
+					</tr>
+					<tr>
+						<td><b>01/24/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=145">Banjo Blues</a></td>
+					</tr>
+					<tr>
+						<td><b>01/22/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=144">Big Game Hunter</a></td>
+					</tr>
+					<tr>
+						<td><b>01/21/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=143">Funny Prank</a></td>
+					</tr>
+					<tr>
+						<td><b>01/19/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=142">Cone Fan</a></td>
+					</tr>
+					<tr>
+						<td><b>01/17/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=141">Ankle-Deep In Horse Shit</a></td>
+					</tr>
+					<tr>
+						<td><b>01/16/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=140">Unviable Fetal Anomally</a></td>
+					</tr>
+					<tr>
+						<td><b>01/15/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=139">Jack-Be-Nimble</a></td>
+					</tr>
+					<tr>
+						<td><b>01/14/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=138">Great Dance</a></td>
+					</tr>
+					<tr>
+						<td><b>01/11/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=137">Juggle Queen</a></td>
+					</tr>
+					<tr>
+						<td><b>01/11/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=136">Jungle Queen</a></td>
+					</tr>
+					<tr>
+						<td><b>01/09/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=135">Turd-Rex</a></td>
+					</tr>
+					<tr>
+						<td><b>01/08/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=134">Legendary Cowboy</a></td>
+					</tr>
+					<tr>
+						<td><b>01/07/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=133">Trolley Follies</a></td>
+					</tr>
+					<tr>
+						<td><b>01/05/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=132">Fun Surprise</a></td>
+					</tr>
+					<tr>
+						<td><b>01/04/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=131">Tony Shalhoub</a></td>
+					</tr>
+					<tr>
+						<td><b>01/02/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=130">Unethical Comic</a></td>
+					</tr>
+					<tr>
+						<td><b>01/02/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=129">Stupid Friends</a></td>
+					</tr>
+					<tr>
+						<td><b>01/01/07</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=128">The Best Butler</a></td>
+					</tr>
+					<tr>
+						<td><b>12/20/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=127">Unusual Wedding Ceremony</a></td>
+					</tr>
+					<tr>
+						<td><b>12/19/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=126">Grateful Joe</a></td>
+					</tr>
+					<tr>
+						<td><b>12/17/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=125">Detective Blowjob</a></td>
+					</tr>
+					<tr>
+						<td><b>12/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=124">Criminal Detective</a></td>
+					</tr>
+					<tr>
+						<td><b>12/13/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=123">Carnival Caper</a></td>
+					</tr>
+					<tr>
+						<td><b>12/12/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=122">Karate-Fu</a></td>
+					</tr>
+					<tr>
+						<td><b>12/11/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=121">Unpleasant Jim</a></td>
+					</tr>
+					<tr>
+						<td><b>12/11/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=120">Cheese Times</a></td>
+					</tr>
+					<tr>
+						<td><b>12/07/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=119">Lame Daydream</a></td>
+					</tr>
+					<tr>
+						<td><b>12/06/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=118">Not Pretending to Ignore a Fart</a></td>
+					</tr>
+					<tr>
+						<td><b>12/05/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=117">Funny Faces</a></td>
+					</tr>
+					<tr>
+						<td><b>12/04/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=116">Pork Oinklers</a></td>
+					</tr>
+					<tr>
+						<td><b>12/03/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=115">Steve Fucker</a></td>
+					</tr>
+					<tr>
+						<td><b>11/23/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=114">Unwarranted Erection</a></td>
+					</tr>
+					<tr>
+						<td><b>11/22/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=113">Snowman Impersonator</a></td>
+					</tr>
+					<tr>
+						<td><b>11/21/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=112">Robophilia</a></td>
+					</tr>
+					<tr>
+						<td><b>11/21/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=111">Awake at the Wheel</a></td>
+					</tr>
+					<tr>
+						<td><b>11/19/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=110">Blimp Ace</a></td>
+					</tr>
+					<tr>
+						<td><b>11/17/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=109">Steve Eater</a></td>
+					</tr>
+					<tr>
+						<td><b>11/15/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=108">A Boy and His Iron</a></td>
+					</tr>
+					<tr>
+						<td><b>11/15/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=107">Ape Fighter</a></td>
+					</tr>
+					<tr>
+						<td><b>11/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=106">Idiotic Fantasy</a></td>
+					</tr>
+					<tr>
+						<td><b>11/12/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=105">Rave Reviews!</a></td>
+					</tr>
+					<tr>
+						<td><b>11/09/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=104">Poop Palace</a></td>
+					</tr>
+					<tr>
+						<td><b>11/09/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=103">Voyage To The Center Of The Sun</a></td>
+					</tr>
+					<tr>
+						<td><b>11/07/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=102">Bastard Saver</a></td>
+					</tr>
+					<tr>
+						<td><b>11/07/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=101">Being Billy Whitaker</a></td>
+					</tr>
+					<tr>
+						<td><b>11/06/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=100">Being Naked With Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>11/02/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=099">Free Corn</a></td>
+					</tr>
+					<tr>
+						<td><b>11/02/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=098">Underground Funk Railroad</a></td>
+					</tr>
+					<tr>
+						<td><b>10/31/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=097">Pretending To Be Someone's Baby</a></td>
+					</tr>
+					<tr>
+						<td><b>10/31/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=096">Dumpy Dykes</a></td>
+					</tr>
+					<tr>
+						<td><b>10/27/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=095">Robocycle</a></td>
+					</tr>
+					<tr>
+						<td><b>10/25/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=094">Clean Sweep!</a></td>
+					</tr>
+					<tr>
+						<td><b>10/23/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=093">Stupid-Seeking Missile</a></td>
+					</tr>
+					<tr>
+						<td><b>10/23/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=092">Coffin Swap</a></td>
+					</tr>
+					<tr>
+						<td><b>10/20/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=091">Tumor Rick</a></td>
+					</tr>
+					<tr>
+						<td><b>10/19/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=090">Spice Fan</a></td>
+					</tr>
+					<tr>
+						<td><b>10/17/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=089">Ugly Gonzalez</a></td>
+					</tr>
+					<tr>
+						<td><b>10/16/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=088">Sports Hero</a></td>
+					</tr>
+					<tr>
+						<td><b>10/15/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=087">The Smartest Student</a></td>
+					</tr>
+					<tr>
+						<td><b>10/12/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=086">Being Naked With Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>10/11/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=085">Surly Earl</a></td>
+					</tr>
+					<tr>
+						<td><b>10/10/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=084">Math-Master</a></td>
+					</tr>
+					<tr>
+						<td><b>10/09/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=083">The Modern Homosexual</a></td>
+					</tr>
+					<tr>
+						<td><b>10/08/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=082">Brain Food</a></td>
+					</tr>
+					<tr>
+						<td><b>10/05/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=081">The Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>10/04/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=080">Fun Uncle</a></td>
+					</tr>
+					<tr>
+						<td><b>10/03/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=079">Excellent Friend</a></td>
+					</tr>
+					<tr>
+						<td><b>10/02/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=078">Loveable Family Member</a></td>
+					</tr>
+					<tr>
+						<td><b>10/01/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=077">Class Act</a></td>
+					</tr>
+					<tr>
+						<td><b>09/28/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=076">Naturally Great Guy</a></td>
+					</tr>
+					<tr>
+						<td><b>09/27/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=075">Ultra Fine Human</a></td>
+					</tr>
+					<tr>
+						<td><b>09/26/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=074">Mayhem Madness</a></td>
+					</tr>
+					<tr>
+						<td><b>09/25/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=073">NBA Dreams!</a></td>
+					</tr>
+					<tr>
+						<td><b>09/24/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=072">Being Naked With Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>09/21/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=071">Cool Helmet</a></td>
+					</tr>
+					<tr>
+						<td><b>09/20/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=070">What if???</a></td>
+					</tr>
+					<tr>
+						<td><b>09/19/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=069">Count Bloodula</a></td>
+					</tr>
+					<tr>
+						<td><b>09/18/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=068">Funky Fun!</a></td>
+					</tr>
+					<tr>
+						<td><b>09/17/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=067">The Boy Who Lied</a></td>
+					</tr>
+					<tr>
+						<td><b>09/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=066">The Best Winner</a></td>
+					</tr>
+					<tr>
+						<td><b>09/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=065">Great Ambition</a></td>
+					</tr>
+					<tr>
+						<td><b>09/12/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=064">Cal-I'm-Sorry Calamari</a></td>
+					</tr>
+					<tr>
+						<td><b>09/11/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=063">Calamari Calamity</a></td>
+					</tr>
+					<tr>
+						<td><b>09/10/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=062">Clam Calamity</a></td>
+					</tr>
+					<tr>
+						<td><b>09/07/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=061">Claus for Alarm</a></td>
+					</tr>
+					<tr>
+						<td><b>08/29/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=060">Prostitution</a></td>
+					</tr>
+					<tr>
+						<td><b>08/27/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=059">Cubix</a></td>
+					</tr>
+					<tr>
+						<td><b>08/25/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=058">The Ugliest Girl</a></td>
+					</tr>
+					<tr>
+						<td><b>08/23/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=057">Birthday Hooray</a></td>
+					</tr>
+					<tr>
+						<td><b>08/22/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=056">Jungle Fever</a></td>
+					</tr>
+					<tr>
+						<td><b>08/21/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=055">Magic Train Land</a></td>
+					</tr>
+					<tr>
+						<td><b>08/20/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=054">Polish Roulette</a></td>
+					</tr>
+					<tr>
+						<td><b>08/18/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=053">Hey! Whatchoo Lookin' At?</a></td>
+					</tr>
+					<tr>
+						<td><b>08/17/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=052">Famous Ape</a></td>
+					</tr>
+					<tr>
+						<td><b>08/16/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=051">Rocket Boat!</a></td>
+					</tr>
+					<tr>
+						<td><b>08/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=050">The Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>08/13/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=049">Being Naked With Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>08/10/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=048">Porn Problem</a></td>
+					</tr>
+					<tr>
+						<td><b>08/10/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=047">Dildo Dilemma</a></td>
+					</tr>
+					<tr>
+						<td><b>08/08/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=046">Dill Dilemma</a></td>
+					</tr>
+					<tr>
+						<td><b>08/08/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=045">Corn Conundrum</a></td>
+					</tr>
+					<tr>
+						<td><b>08/07/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=044">Macho Bernard</a></td>
+					</tr>
+					<tr>
+						<td><b>08/04/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=043">Macho Steve</a></td>
+					</tr>
+					<tr>
+						<td><b>08/03/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=042">Horndogglers</a></td>
+					</tr>
+					<tr>
+						<td><b>08/02/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=041">Cool Squad</a></td>
+					</tr>
+					<tr>
+						<td><b>08/01/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=040">Rollin' Wit Lil' Cal</a></td>
+					</tr>
+					<tr>
+						<td><b>07/30/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=039">Amazing Albert</a></td>
+					</tr>
+					<tr>
+						<td><b>07/27/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=038">It's a Girl!</a></td>
+					</tr>
+					<tr>
+						<td><b>07/26/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=037">Liver and Bunyons</a></td>
+					</tr>
+					<tr>
+						<td><b>07/25/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=036">The Winston-Lomville Corn Tribune Herald</a></td>
+					</tr>
+					<tr>
+						<td><b>07/25/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=035">Wig Fan</a></td>
+					</tr>
+					<tr>
+						<td><b>07/23/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=034">World's Biggest Asshole</a></td>
+					</tr>
+					<tr>
+						<td><b>07/20/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=033">Stupid Dream</a></td>
+					</tr>
+					<tr>
+						<td><b>07/19/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=032">Air-Tight Alibi</a></td>
+					</tr>
+					<tr>
+						<td><b>07/18/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=031">Amusement Park for Dads</a></td>
+					</tr>
+					<tr>
+						<td><b>07/17/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=030">Dumb Wish</a></td>
+					</tr>
+					<tr>
+						<td><b>07/16/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=029">Fashion Blunder</a></td>
+					</tr>
+					<tr>
+						<td><b>07/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=028">Big Celebrity</a></td>
+					</tr>
+					<tr>
+						<td><b>07/13/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=027">Chess Masters</a></td>
+					</tr>
+					<tr>
+						<td><b>07/11/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=026">Scary Serpents</a></td>
+					</tr>
+					<tr>
+						<td><b>07/10/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=025">The Hunters</a></td>
+					</tr>
+					<tr>
+						<td><b>07/10/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=024">Wife Swap</a></td>
+					</tr>
+					<tr>
+						<td><b>07/06/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=023">Queen for a Day</a></td>
+					</tr>
+					<tr>
+						<td><b>07/05/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=022">What Would You Do for a Thousand Bucks?</a></td>
+					</tr>
+					<tr>
+						<td><b>07/04/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=021">Unwelcome Guests</a></td>
+					</tr>
+					<tr>
+						<td><b>07/03/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=020">Being Naked With Old People</a></td>
+					</tr>
+					<tr>
+						<td><b>07/02/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=019">Best Moustache</a></td>
+					</tr>
+					<tr>
+						<td><b>06/29/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=018">Bert &amp; Ernie</a></td>
+					</tr>
+					<tr>
+						<td><b>06/29/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=017">Hang Gliding Cowboy</a></td>
+					</tr>
+					<tr>
+						<td><b>06/27/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=016">Weird Sandwich</a></td>
+					</tr>
+					<tr>
+						<td><b>06/26/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=015">Horse Surgeon</a></td>
+					</tr>
+					<tr>
+						<td><b>06/25/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=014">The Colossus</a></td>
+					</tr>
+					<tr>
+						<td><b>06/22/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=013">Slamburgers!</a></td>
+					</tr>
+					<tr>
+						<td><b>06/21/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=012">For Better Or For Wurst</a></td>
+					</tr>
+					<tr>
+						<td><b>06/20/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=011">In Charge of Dogs</a></td>
+					</tr>
+					<tr>
+						<td><b>06/19/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=010">Pillow Talk</a></td>
+					</tr>
+					<tr>
+						<td><b>06/18/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=009">The Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>06/16/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=008">Phallic Spoon</a></td>
+					</tr>
+					<tr>
+						<td><b>06/14/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=007">Weird Hobo</a></td>
+					</tr>
+					<tr>
+						<td><b>06/13/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=006">Great Comedian</a></td>
+					</tr>
+					<tr>
+						<td><b>06/12/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=005">Farting Pirate</a></td>
+					</tr>
+					<tr>
+						<td><b>06/11/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=004">The Roarosaurs</a></td>
+					</tr>
+					<tr>
+						<td><b>06/09/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=003">Pink Slip!</a></td>
+					</tr>
+					<tr>
+						<td><b>06/07/06</b></td>
+						<td><a href="comic.html?comic=scribblettes&page=002">Outta Sight!</a></td>
+					</tr>
+					<tr>
+						<td><b>06/06/06</b></td>
+							<td><a href="comic.html?comic=scribblettes&page=001">Being Naked With Old People</a></td>
+					</tr>
+				</tbody></table>
 			</div>
 		</div>
 		<div class="footer">


### PR DESCRIPTION
On several occasions I wanted to search for a scribblette by name, but
that info hadn't been copied over from the original site.